### PR TITLE
Upgrade patch level dependencies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.2] - 2016-06-01
+### Changed
+- Upgrade go to 1.5.4
+- Upgrade hub to 2.2.3
+- Specify tag for go-makefile Docker image
+
 ## [1.0.1] - 2016-02-15
 ### Fixed
 - Ensure `make test` downloads test packages
@@ -18,5 +24,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Initial Release
 
 [Unreleased]: https://github.com/civisanalytics/go-makefile/compare/v1.0.1...HEAD
+[1.0.2]: https://github.com/civisanalytics/go-makefile/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/civisanalytics/go-makefile/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/civisanalytics/go-makefile/commit/5874cf92241d4f5a25a7ccb444fe2e98e136c666

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:14.04
 
-ENV GOVERSION 1.5.3
-
 RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          curl build-essential ca-certificates git mercurial bzr \
                       && rm -rf /var/lib/apt/lists/*
+
+ENV GOVERSION 1.5.4
 
 ENV GOROOT /goroot
 ENV GOPATH /gopath

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -L https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar
 
 RUN go get github.com/mitchellh/gox
 
-RUN curl -L https://github.com/github/hub/releases/download/v2.2.2/hub-linux-amd64-2.2.2.tgz \
-    | tar xzf - -C /opt --strip-components=2 hub-linux-amd64-2.2.2/bin/hub
+RUN curl -L https://github.com/github/hub/releases/download/v2.2.3/hub-linux-amd64-2.2.3.tgz \
+    | tar xzf - -C /opt --strip-components=2 hub-linux-amd64-2.2.3/bin/hub
 
 CMD gox

--- a/GoMakefile
+++ b/GoMakefile
@@ -3,12 +3,12 @@
 # license that can be found in the LICENSE.txt file at
 # https://github.com/civisanalytics/go-makefile
 
-GO_MAKEFILE_VERSION := 1.0.1
+GO_MAKEFILE_VERSION := 1.0.2
 
 SRC := /gopath/src/$(REPOSITORY)
 
 ifndef DOCKER_IMAGE
-	DOCKER_IMAGE := civisanalytics/go-makefile
+	DOCKER_IMAGE := civisanalytics/go-makefile:v$(GO_MAKEFILE_VERSION)
 endif
 DOCKER_RUN := docker run --rm -v $(shell pwd):$(SRC) -w $(SRC) -e GITHUB_TOKEN $(DOCKER_IMAGE)
 

--- a/test/go-makefile.bats
+++ b/test/go-makefile.bats
@@ -96,8 +96,8 @@ EOT
   # echo $sha256sums
 
   # two spaces between checksum and filename
-  expected_sha256sums="48b360b97045dbd3c98273059a8b30dcbd139242d0bbee59e2b23a13e29a68b2  example_1.0.0_darwin_amd64.tar.bz2
-1e0f782d56dad26ab8533a1a9f6bbec8a8029249fd4dd5abbae545c625c9b2f9  example_1.0.0_linux_amd64.tar.bz2"
+  expected_sha256sums="ebebe37477107d7f35f70f5e3011f188a77596a6f78cde724ee56b42b54f9cce  example_1.0.0_darwin_amd64.tar.bz2
+2924e4f10fbd9fdce033a586a78e9ddd9731e4765a82aa30956fcc758f6f8662  example_1.0.0_linux_amd64.tar.bz2"
 
   [ "$sha256sums" = "$expected_sha256sums" ]
 }


### PR DESCRIPTION
- Upgrade go to 1.5.4
- Upgrade hub to 2.2.3
- Specify tag for go-makefile Docker image
