### PR TITLE
GoMakefile: use a plausable timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.3] - 2016-06-08
+### Changed
+- Use a plausable mtime when creating the archive to avoid tar warnings
+
 ## [1.0.2] - 2016-06-01
 ### Changed
 - Upgrade go to 1.5.4

--- a/GoMakefile
+++ b/GoMakefile
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE.txt file at
 # https://github.com/civisanalytics/go-makefile
 
-GO_MAKEFILE_VERSION := 1.0.2
+GO_MAKEFILE_VERSION := 1.0.3
 
 SRC := /gopath/src/$(REPOSITORY)
 

--- a/GoMakefile
+++ b/GoMakefile
@@ -12,7 +12,7 @@ ifndef DOCKER_IMAGE
 endif
 DOCKER_RUN := docker run --rm -v $(shell pwd):$(SRC) -w $(SRC) -e GITHUB_TOKEN $(DOCKER_IMAGE)
 
-REPRODUCIBLE_TAR := --mtime='1970-01-01 00:00Z' --owner=root --group=root --numeric-owner
+REPRODUCIBLE_TAR := --mtime='2001-01-01 01:01Z' --owner=root --group=root --numeric-owner
 
 .PHONY: check-env build test release
 

--- a/test/go-makefile.bats
+++ b/test/go-makefile.bats
@@ -93,11 +93,11 @@ EOT
 
   sha256sums=$(<"${TMP_PROJECTDIR}/build/SHA256SUMS")
 
-  # echo $sha256sums
+  echo $sha256sums
 
   # two spaces between checksum and filename
-  expected_sha256sums="ebebe37477107d7f35f70f5e3011f188a77596a6f78cde724ee56b42b54f9cce  example_1.0.0_darwin_amd64.tar.bz2
-2924e4f10fbd9fdce033a586a78e9ddd9731e4765a82aa30956fcc758f6f8662  example_1.0.0_linux_amd64.tar.bz2"
+  expected_sha256sums="863ac89c622fc4f4ca2871bcab33037983fd661d28200f6f5bed84b9d46ab79f  example_1.0.0_darwin_amd64.tar.bz2
+db6de52790e2b13d918579a2eaf19adf6e3d9e6add0cdf41e74e3b58caa75fe7  example_1.0.0_linux_amd64.tar.bz2"
 
   [ "$sha256sums" = "$expected_sha256sums" ]
 }


### PR DESCRIPTION
The tar --mtime is set so the SHA256SUMS hash of the archive is
consistent when building.

otherwise extracting the tar would result with this warning in certain
environments

```
tar: implausibly old time stamp 1970-01-01 00:00:00
```
