### PR TITLE
[CIVP-23714] Upgrade Go to 1.16.3

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Description
+Please provide a brief description of what this pull request is trying to accomplish.
+
+>
+
+## Context, Consequences, & Considerations
+Please step through the following list, pausing at each item to consider your change in relation to the item's context.
+Check the box to mark that it applies, and enter your relevant notes under the item.
+
+- [ ] Security: This has security implications. This includes (but not limited to) adding users, modifying user/app permissions, network rules/policies, changing a system interconnection, or changing an authorization strategy.
+  - [ ] This PR does not require security review. These changes are part of a project plan that has already undergone security review. The link is provided below.
+  - [ ] This PR requires security review. The `security` label is attached to this PR and a review from `Security Team` will be requested.
+
+>
+
+- [ ] Execution: This change requires commands to be run outside of the normal merge.
+
+>
+
+- [ ] Execution: Applying this change will modify production data. This includes (but not limited to) database migrations, rake tasks that modify data, or other processes.
+
+>
+
+- [ ] Impact: This change may cause service interruptions.
+
+>
+
+- [ ] Testing: How did you test this change (unit tests, acceptance tests, etc.)? Did you do any manual testing?
+
+>
+
+- [ ] Testing: How will you confirm this change once it's merged?
+
+>
+
+- [ ] Documentation: Documentation to reflect this change has been added to Confluence or Zendesk.
+
+>
+
+- [ ] **All items of the checklist have been considered and this PR description is complete.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.2.0]
+## [1.2.0] - 2021-04-16
 ### Added
 Pull request template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0]
+### Added
+Pull request template
+
+### Changed
+Upgrade Go to 1.16.3
+Update download location for Go linux binary
+Set GO111MODULE environment variable to auto to enable support for GOPATH mode due to breaking change in Go 1.16
+
 ## [1.1.0]
 ### Changed
 Update Go version to 1.10.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,16 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y -q \
                          curl build-essential ca-certificates git mercurial bzr \
                       && rm -rf /var/lib/apt/lists/*
 
-ENV GOVERSION 1.10.1
+ENV GOVERSION 1.16.3
 
 ENV GOROOT /goroot
 ENV GOPATH /gopath
+ENV GO111MODULE auto
 
 RUN mkdir $GOROOT $GOPATH
 ENV PATH $GOROOT/bin:$GOPATH/bin:/opt:$PATH
 
-RUN curl -L https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz \
+RUN curl -L https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz \
     | tar xzf - -C $GOROOT --strip-components=1
 
 RUN go get github.com/mitchellh/gox

--- a/GoMakefile
+++ b/GoMakefile
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE.txt file at
 # https://github.com/civisanalytics/go-makefile
 
-GO_MAKEFILE_VERSION := 1.1.0
+GO_MAKEFILE_VERSION := 1.2.0
 
 SRC := /gopath/src/$(REPOSITORY)
 

--- a/test/go-makefile.bats
+++ b/test/go-makefile.bats
@@ -96,8 +96,8 @@ EOT
   echo $sha256sums
 
   # two spaces between checksum and filename
-  expected_sha256sums="b656f37a49b5ec5f0de00d76224ca3ac1243182031029cb5a94f424c0b50e054  example_1.0.0_darwin_amd64.tar.bz2
-d15305932427664a18d441c708dd0805016afa6f9f7570aee827a3cf05ef94a1  example_1.0.0_linux_amd64.tar.bz2"
+  expected_sha256sums="95b68bfb48ff3bc02392ae4fb3084549fdb529fd74c586b6d3ed98f517321c53  example_1.0.0_darwin_amd64.tar.bz2
+298b83d9332e7d60aa3b71ca6ac7714954af443a361b1e76068ee3574fb70421  example_1.0.0_linux_amd64.tar.bz2"
 
   [ "$sha256sums" = "$expected_sha256sums" ]
 }


### PR DESCRIPTION
- Upgrade Go to 1.16.3
- Update location for download of Go linux binary
- Update Dockerfile due to changes in how Go is installed in v1.16.3
- Add new PR template for Fedramp